### PR TITLE
Support 'skipped_deps' and 'extra_aliased_targets' in Cargo.toml

### DIFF
--- a/src/bazel.rs
+++ b/src/bazel.rs
@@ -112,6 +112,7 @@ mod tests {
       build_script_target: None,
       additional_deps: Vec::new(),
       additional_flags: Vec::new(),
+      extra_aliased_targets: Vec::new(),
     }
   }
 
@@ -137,6 +138,7 @@ mod tests {
       build_script_target: None,
       additional_deps: Vec::new(),
       additional_flags: Vec::new(),
+      extra_aliased_targets: Vec::new(),
     }
   }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -33,6 +33,7 @@ pub struct CrateContext {
   pub build_script_target: Option<BuildTarget>,
   pub additional_deps: Vec<String>,
   pub additional_flags: Vec<String>,
+  pub extra_aliased_targets: Vec<String>,
   // TODO(acmcarther): Consider plugin topic
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -27,12 +27,32 @@ pub struct CrateSettings {
   /** Dependencies to be added to a crate, in the form "//etc".*/
   #[serde(default)]
   pub additional_deps: Vec<String>,
+
+  /** Dependencies to be removed from a crate, in the form "//etc".*/
+  #[serde(default)]
+  pub skipped_deps: Vec<String>,
+
+  /**
+  * Library targets that should be aliased in the root BUILD file.
+  *
+  * This is useful to facilitate using binary utility crates, such as bindgen, as part of genrules.
+  */
+  #[serde(default)]
+  pub extra_aliased_targets: Vec<String>,
+
   /** Flags to be added to the crate compilation process, in the form "--flag". */
   #[serde(default)]
   pub additional_flags: Vec<String>,
 
+  /**
+   * Whether or not to generate the build script that goes with this crate.
+   *
+   * Many build scripts will not function, as they will still be built hermetically. However, build
+   * scripts that merely generate files into OUT_DIR may be functional.
+   */
   #[serde(default = "default_gen_buildrs")]
   pub gen_buildrs: bool,
+
 }
 
 fn default_gen_buildrs() -> bool {

--- a/src/templates/partials/rust_binary.template
+++ b/src/templates/partials/rust_binary.template
@@ -1,9 +1,13 @@
 {% set target_name_sanitized = target.name | replace(from="-", to="_") %}
 rust_binary(
-    name = "{{ target_name_sanitized }}",
+    # Prefix bin name to disambiguate from (probable) collision with lib name
+    # N.B.: The exact form of this is subject to change.
+    name = "cargo_bin_{{ target_name_sanitized }}",
     crate_root = "{{ target.path }}",
     srcs = glob(["**/*.rs"]),
     deps = [
+        # Binaries get an implicit dependency on their lib
+        ":{{crate.pkg_name | replace(from="-", to="_") }}",
         {% for dependency in crate.dependencies %}
         "{{path_prefix}}/vendor/{{dependency.name}}-{{dependency.version}}:{{dependency.name | replace(from="-", to="_") }}",
         {% endfor %}

--- a/src/templates/workspace.BUILD.template
+++ b/src/templates/workspace.BUILD.template
@@ -13,4 +13,12 @@ alias(
     actual = "{{path_prefix}}/vendor/{{crate.pkg_name}}-{{crate.pkg_version}}:{{crate_name_sanitized}}",
 )
 {% endif %}
+{% for aliased_target in crate.extra_aliased_targets %}
+alias(
+    # Extra aliased target, from raze configuration
+    # N.B.: The exact form of this is subject to change.
+    name = "{{aliased_target}}",
+    actual = "{{path_prefix}}/vendor/{{crate.pkg_name}}-{{crate.pkg_version}}:{{aliased_target}}",
+)
+{% endfor %}
 {% endfor %}


### PR DESCRIPTION
This makes the necessary changes to support #19 and #20.

As part of that, it renames the generated targets for rust_binary rules in order to avoid what are apparently common naming collisions in cargo libraries.

The test suite for cargo-raze is incredibly deficient, but I have verified that this works in cargo-raze-examples (after a _very_ tiny hotfix in bindgen https://github.com/rust-lang-nursery/rust-bindgen/pull/1220).