### PR TITLE
Update readme and clean up formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ A cargo subcommand to generate platform-specific BUILD files.
 See examples in the automatically updated examples repository:
 [github.com/acmcarther/cargo-raze-examples](https://github.com/acmcarther/cargo-raze-examples)
 
+Furthermore, see the crate bonanza in the "crater" repo, which brings in many
+of the most popular crates. This repo has some of the Raze settings that will be
+necessary to build some crates:
+[github.com/acmcarther/cargo-raze-crater Cargo.toml](https://github.com/acmcarther/cargo-raze-crater/blob/master/cargo/Cargo.toml)
+
 ## Caution: Under Development!
 
 This is still under heavy development. It has few tests and is very unstable. It relies on some custom changes to the [rules_rust](https://github.com/bazel/rules_rust) library to support build scripts and duplicate crate definitions. The changes are available in the [diff between my repo and master](https://github.com/bazelbuild/rules_rust/compare/master...acmcarther:acm-06-17-hotfixes).
@@ -23,6 +28,26 @@ So far you've either stuck with Cargo and made do with `build.rs` files, or migr
 
 ## Getting Started
 
+To use Raze, you'll need to:
+
+1. Set up your WORKSPACE to contain Rust rules
+2. If Vendoring:
+  a. Set up your cargo/ directory for vendoring
+  b. Install cargo-vendor, and cargo-raze
+  c. Generate your lock file
+  d. Vendor your dependencies
+  e. Generate your BUILD files into the vendored directories
+3. If not vendoring
+  a. Set up your cargo/ directory for remote dependencies
+  b. Install cargo-raze
+  c. Generate your BUILD files
+  d. Add the crate fetching snippet into your WORKSPACE file.
+
+See below for individual step details
+
+
+### Set up your WORKSPACE to contain Rust rules
+
 In your Bazel WORKSPACE, include the rust rules:
 ```python
 git_repository(
@@ -38,6 +63,8 @@ rust_repositories()
 Now, choose between vendoring (checking dependencies into repo) or not vendoring
 
 ### Vendoring dependencies locally (default)
+
+#### Set up your cargo/ directory for vendoring
 Create a `Cargo.toml` containing the crates you want to include and configuration for raze:
 ```toml
 [package]
@@ -55,17 +82,32 @@ workspace_path = "//label/for/vendored/crates" # The WORKSPACE relative path to 
 target = "x86_64-unknown-linux-gnu" # The target to generate BUILD rules for.
 ```
 
+#### Install cargo-vendor and cargo-raze
 Then, in the directory containing the `Cargo.toml`. Project root is fine:
 ```bash
 cargo install cargo-vendor
 cargo install cargo-raze
+```
+
+#### Generate your lock file
+```bash
 cargo generate-lockfile
+```
+
+#### Vendor your dependencies
+```bash
 cargo vendor -x
+```
+
+#### Generate your BUILD files into the vendored directories
+```
 cargo raze
 ```
 Your dependencies each get a shiny new `BUILD` file that bazel can use to link your dependencies up.
 
 ### Remote dependencies
+
+#### Set up your cargo/ directory for vendoring
 Create a `Cargo.toml` containing the crates you want to include and configuration for raze:
 ```toml
 [package]
@@ -84,15 +126,22 @@ target = "x86_64-unknown-linux-gnu" # The target to generate BUILD rules for.
 genmode = "Remote" # Have Bazel pull the dependencies down
 ```
 
+#### Install cargo-raze
 Then, in the directory containing the `Cargo.toml`. Project root is fine:
 ```bash
 cargo install cargo-raze
+```
+
+#### Generate your BUILD files
+```bash
 cargo raze
 ```
 You now have three files: A "crates.bzl" file with a repository function to pull
 down your deps, a BUILD file that references your explicit dependencies, and a
 set of dep build files for each of your dependencies.
 
+
+#### Add the crate fetching snippet into your WORKSPACE file
 In order for Bazel to know about the dependencies, you need to execute the
 repository function provided in "crates.bzl". To do that, add a snippet as
 follows to your root WORKSPACE file.
@@ -111,6 +160,7 @@ See these examples of providing crate configuration:
 
 - [basic-example](https://github.com/acmcarther/cargo-raze-examples/blob/master/bazel/hello_cargo_library/Cargo.toml)
 - [complicated-example](https://github.com/acmcarther/cargo-raze-examples/blob/master/bazel/complicated_cargo_library/Cargo.toml)
+- [complicated-example-remote](https://github.com/acmcarther/cargo-raze-examples/blob/master/bazel/complicated_cargo_library_remote/Cargo.toml)
 - [openssl-example](https://github.com/acmcarther/compile_openssl/blob/master/cargo/Cargo.toml)
 
 The [raze] section is derived from a struct declared in [src/settings.rs](./src/settings.rs).
@@ -120,4 +170,4 @@ The [raze] section is derived from a struct declared in [src/settings.rs](./src/
 - Proper platform detection. Currently we take platform as a configuration parameter. This isn't too hard, just haven't had time.
 - Platform-agnostic generated `BUILD`. I envision mapping the existing platform-specific dependency support down to a handful of supported platforms within the bazel rule, rather than here. That lets us use bazel's `select` construct to support multiple platforms with a single rule.
 - Clean up folder structure
-- Set up dual compilation (compile raze via bazel OR via cargo). Prereq: openssl. Openssl is major pain to compile.
+- Set up dual compilation (compile raze via bazel OR via cargo).

--- a/README.md
+++ b/README.md
@@ -32,16 +32,16 @@ To use Raze, you'll need to:
 
 1. Set up your WORKSPACE to contain Rust rules
 2. If Vendoring:
-    a. Set up your cargo/ directory for vendoring
-    b. Install cargo-vendor, and cargo-raze
-    c. Generate your lock file
-    d. Vendor your dependencies
-    e. Generate your BUILD files into the vendored directories
+    1. Set up your cargo/ directory for vendoring
+    2. Install cargo-vendor, and cargo-raze
+    3. Generate your lock file
+    4. Vendor your dependencies
+    5. Generate your BUILD files into the vendored directories
 3. If not vendoring
-    a. Set up your cargo/ directory for remote dependencies
-    b. Install cargo-raze
-    c. Generate your BUILD files
-    d. Add the crate fetching snippet into your WORKSPACE file.
+    1. Set up your cargo/ directory for remote dependencies
+    2. Install cargo-raze
+    3. Generate your BUILD files
+    4. Add the crate fetching snippet into your WORKSPACE file.
 
 See below for individual step details
 

--- a/README.md
+++ b/README.md
@@ -32,16 +32,16 @@ To use Raze, you'll need to:
 
 1. Set up your WORKSPACE to contain Rust rules
 2. If Vendoring:
-  a. Set up your cargo/ directory for vendoring
-  b. Install cargo-vendor, and cargo-raze
-  c. Generate your lock file
-  d. Vendor your dependencies
-  e. Generate your BUILD files into the vendored directories
+    a. Set up your cargo/ directory for vendoring
+    b. Install cargo-vendor, and cargo-raze
+    c. Generate your lock file
+    d. Vendor your dependencies
+    e. Generate your BUILD files into the vendored directories
 3. If not vendoring
-  a. Set up your cargo/ directory for remote dependencies
-  b. Install cargo-raze
-  c. Generate your BUILD files
-  d. Add the crate fetching snippet into your WORKSPACE file.
+    a. Set up your cargo/ directory for remote dependencies
+    b. Install cargo-raze
+    c. Generate your BUILD files
+    d. Add the crate fetching snippet into your WORKSPACE file.
 
 See below for individual step details
 


### PR DESCRIPTION
This PR adds the "cargo-raze-crater" example repo, which contains a huge number of dependencies being pulled down (remotely) and compiled. The PR also adds a bit more formatting to some of the instructions.